### PR TITLE
Fix /addgames: file-path guard rejects the raw XML request body

### DIFF
--- a/es-app/src/Gamelist.cpp
+++ b/es-app/src/Gamelist.cpp
@@ -113,7 +113,7 @@ std::vector<FileData*> loadGamelistFile(const std::string xmlpath, SystemData* s
 {	
 	std::vector<FileData*> ret;
 
-	if (Utils::String::toLower(Utils::FileSystem::getExtension(xmlpath)) != ".xml" || !Utils::FileSystem::isRegularFile(xmlpath))
+	if (fromFile && (Utils::String::toLower(Utils::FileSystem::getExtension(xmlpath)) != ".xml" || !Utils::FileSystem::isRegularFile(xmlpath)))
 		return ret;
 
 	LOG(LogInfo) << "Parsing XML file \"" << xmlpath << "\"...";


### PR DESCRIPTION
﻿## Problem

`POST /addgames/{system}` no longer works: it always answers `204 No game added / updated` and never updates any game, whatever the payload.

## Root cause

The HTTP handler passes the raw request body to `loadGamelistFile` with `fromFile = false`:

```cpp
auto fileList = loadGamelistFile(req.body, system, fileMap, SIZE_MAX, false);
```

but `loadGamelistFile` starts with an unconditional file-path guard:

```cpp
if (Utils::String::toLower(Utils::FileSystem::getExtension(xmlpath)) != ".xml" || !Utils::FileSystem::isRegularFile(xmlpath))
    return ret;
```

A raw XML body has no `.xml` extension and is not a regular file, so the function always returns an empty list and the endpoint is a silent no-op.

## Fix

Only apply the guard when the argument really is a file path (`fromFile == true`):

```cpp
if (fromFile && (Utils::String::toLower(Utils::FileSystem::getExtension(xmlpath)) != ".xml" || !Utils::FileSystem::isRegularFile(xmlpath)))
    return ret;
```

The raw-body path keeps its own error handling (`doc.load_string` result is checked right below), and the guard still protects every file-based caller (`parseGamelist`, gamelist recovery).

## Notes

- Verified against an older EmulationStation build that predates this guard: `/addgames` works there, which confirms the guard introduced the regression.
- Found while integrating a companion tool that uses the local HTTP API to refresh game cards live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
